### PR TITLE
fix: click not work when use in custom tabbar

### DIFF
--- a/.changeset/quick-ants-destroy.md
+++ b/.changeset/quick-ants-destroy.md
@@ -1,0 +1,6 @@
+---
+"ossaui": patch
+"ossa-demo": patch
+---
+
+when used in miniapp custom tabbar, click not work as expected

--- a/packages/ossa-demo/src/components/tabbar/demo/index.tsx
+++ b/packages/ossa-demo/src/components/tabbar/demo/index.tsx
@@ -22,7 +22,7 @@ const initialListApi = {
   head: ["参数", "说明", "类型", "默认值"],
   data: [
     {
-      list: ["value", "当前选中的标签索引值，从0开始，可选", "number", "0"],
+      list: ["value", "当前选中的标签索引值，从0开始，必选", "number", "-"],
     },
     {
       list: ["tabsArr", "数据渲染，必选", "<Array><API-TabsArr>", "-"],
@@ -85,7 +85,7 @@ const initialListEvent = {
   head: ["函数名", "说明", "参数"],
   data: [
     {
-      list: ["onClick", "点击时触发", "(item)当前点击的标签，从0开始"],
+      list: ["onClick", "点击时触发", "(item, index)当前点击的标签，从0开始"],
     },
   ],
 };
@@ -117,16 +117,14 @@ const initialTabsArr = [
   },
 ];
 
-function onClick(item: object) {
-  console.log(item);
-}
-
 const demoTitle = "TabBar 标签栏";
 export default function Index() {
   const [listApi] = useState(initialListApi);
   const [tabs] = useState(initialTabsApi);
   const [listEvent] = useState(initialListEvent);
   const [tabsArr] = useState(initialTabsArr);
+  const [tab1Index, setTab1Index] = useState(2);
+  const [tab2Index, setTab2Index] = useState(0);
   const classObject = getClassObject(); //组件修饰
 
   useEffect(() => {
@@ -135,22 +133,37 @@ export default function Index() {
     });
   }, []);
 
+  const onClick = (item: object) => {
+    console.log(item);
+  }
+
+  const handleTab1Click = (item: object, index: number) => {
+    setTab1Index(index)
+    onClick(item)
+  }
+
+  const handleTab2Click = (item: object, index: number) => {
+    setTab2Index(index)
+    onClick(item)
+  }
+
   return (
     <View className={classNames(classObject)}>
       <DemoHeader title={demoTitle}></DemoHeader>
       <DemoBlock fullScreen title='基础'>
         <OsTabBar
-          value={2}
+          value={tab1Index}
           tabsArr={tabsArr}
-          onClick={(item) => onClick(item)}
+          onClick={(item, index) => handleTab1Click(item, index)}
         ></OsTabBar>
       </DemoBlock>
 
       <DemoBlock fullScreen title='固定底部'>
         <OsTabBar
+          value={tab2Index}
           tabsArr={tabsArr}
           isfixedBt
-          onClick={(item) => onClick(item)}
+          onClick={(item, index) => handleTab2Click(item, index)}
         ></OsTabBar>
       </DemoBlock>
 

--- a/packages/ossa/src/components/tabbar/index.tsx
+++ b/packages/ossa/src/components/tabbar/index.tsx
@@ -40,21 +40,17 @@ function getTextStyleObj(props: OsTabBarProps) {
 
 function onClick(
   props: OsTabBarProps,
-  setCurrent: Function,
   item: OsTabBarItemProps,
   index: number
 ) {
-  setCurrent(index);
-  props.onClick && props.onClick(item);
+  props.onClick && props.onClick(item, index);
 }
 
 export default function TabBar(props: OsTabBarProps) {
   const rootClassName = "ossa-tabbar"; //组件
   const classObject = getClassObject(props); //组件修饰
-  const styleObject = props.customStyle;
   const textStyle = getTextStyleObj(props);
-  const { tabsArr } = props;
-  const [current = 0, setCurrent] = useState(props.value);
+  const { customStyle: styleObject, tabsArr, value: current } = props;
 
   return (
     <View
@@ -66,7 +62,7 @@ export default function TabBar(props: OsTabBarProps) {
           className='ossa-tabbar__item'
           key={index}
           style={getItemStyleObj(props, index, current)}
-          onClick={() => onClick(props, setCurrent, item, index)}
+          onClick={() => onClick(props, item, index)}
         >
           {item.useCustomIcon ? (
             index === current ? (

--- a/packages/ossa/types/tabbar.d.ts
+++ b/packages/ossa/types/tabbar.d.ts
@@ -13,8 +13,8 @@ export interface TabBarProps extends OsComponent {
   activeColor?: string;
   defaultColor?: string;
   space?: number;
-  value?: number;
-  onClick?: (v: object) => void;
+  value: number;
+  onClick?: (v: object, index: number) => void;
 }
 
 declare const TabBar: ComponentClass<TabBarProps>;


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NeteaseYanxuan/OSSA/blob/main/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->
<!-- Bugfix or Feature should link relative issue id) -->

**这个 PR 做了什么?** (简要描述所做更改)

修复tabBar组件在小程序自定义tabBar组件中使用时，点击表现不合预期的问题。

主要是因为小程序自定义tabBar在每个每个tab页面都是不同的实例，tabBar的当前状态不应该由组件内部维护，而应该由外部统一维护

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) fix #33 
- [ ] 新功能(Feature) resolve #{issue id}
- [ ] 代码重构(Refactor)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 未涉及平台修改
- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
