### PR TITLE
fix: not vertical center

### DIFF
--- a/.changeset/little-pugs-grin.md
+++ b/.changeset/little-pugs-grin.md
@@ -1,0 +1,5 @@
+---
+"ossaui": patch
+---
+
+fix not vertical center

--- a/packages/ossa/src/style/components/stepper.scss
+++ b/packages/ossa/src/style/components/stepper.scss
@@ -111,6 +111,10 @@
     border-radius: 0;
     text-align: center;
 
+    .weui-input {
+      height: 100%;
+    }
+
     input {
       height: 100%;
     }

--- a/packages/ossa/src/style/components/tag.scss
+++ b/packages/ossa/src/style/components/tag.scss
@@ -38,7 +38,6 @@
 
   &--arrow {
     width: 10px;
-    height: 18px;
     margin-top: -1px;
   }
 


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NeteaseYanxuan/OSSA/blob/main/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->
<!-- Bugfix or Feature should link relative issue id) -->

**这个 PR 做了什么?** (简要描述所做更改)

H5环境下，tag和stepper不垂直居中

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix)
- [ ] 新功能(Feature) resolve #{issue id}
- [ ] 代码重构(Refactor)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 未涉及平台修改
- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
