### PR TITLE
feat(input): 是否显示字符计数器属性名使用 showCount 属性替代

### DIFF
--- a/.changeset/mighty-chicken-float.md
+++ b/.changeset/mighty-chicken-float.md
@@ -1,0 +1,7 @@
+---
+"ossaui": patch
+"ossa-demo": patch
+"ossa-doc": patch
+---
+
+feat: input 组件是否显示字符计数器属性名使用 showCount 属性替代

--- a/packages/ossa-demo/src/components/input/demo/index.tsx
+++ b/packages/ossa-demo/src/components/input/demo/index.tsx
@@ -64,6 +64,14 @@ const initialListApi = {
     {
       list: [
         "countDown",
+        "是否显示字符计数器，textarea有效，可选。`countDown`字段将在未来版本中被移除,请使用`showCount`代替",
+        "boolean",
+        "false",
+      ],
+    },
+    {
+      list: [
+        "showCount",
         "是否显示字符计数器，textarea有效，可选",
         "boolean",
         "false",

--- a/packages/ossa-demo/src/components/input/demo/index.tsx
+++ b/packages/ossa-demo/src/components/input/demo/index.tsx
@@ -190,7 +190,7 @@ export default function Index(props: any) {
             onChange={(v) => {
               setV3(v);
             }}
-            countDown
+            showCount
             maxLength={200}
           ></OsInput>
         </View>
@@ -223,7 +223,7 @@ export default function Index(props: any) {
             onChange={(v) => {
               setV6(v);
             }}
-            countDown
+            showCount
             isDisabled
           ></OsInput>
         </View>

--- a/packages/ossa-doc/docs/组件/input.md
+++ b/packages/ossa-doc/docs/组件/input.md
@@ -154,7 +154,8 @@ const [v6, setV6] = useState("不可编辑的textarea");
 |isReadonly|是否可编辑，可选|boolean|false|
 |isDisabled|表单是否失效，可选|boolean|false|
 |disabledClear|是否隐藏一键删除按钮，可选|boolean|false|
-|countDown|是否显示字符计数器，textarea有效，可选|boolean|false|
+|countDown|是否显示字符计数器，textarea有效，可选，`countDown`字段将在未来版本中被移除,请使用`showCount`代替|boolean|false|
+|showCount|是否显示字符计数器，textarea有效，可选|boolean|false|
 
 
 ### 方法

--- a/packages/ossa/src/components/input/index.tsx
+++ b/packages/ossa/src/components/input/index.tsx
@@ -85,6 +85,7 @@ export default function OsInput(props: OsInputProps) {
     props.value &&
     props.type !== "textarea";
   const editable = !props.isReadonly && !props.isDisabled;
+  const mergedShowCount = props.showCount ?? props.countDown;
   return (
     <View
       className={classNames(rootClassName, classObject, props.className)}
@@ -153,7 +154,7 @@ export default function OsInput(props: OsInputProps) {
           </View>
         )}
       </View>
-      {props.type === "textarea" && props.countDown && (
+      {props.type === "textarea" && mergedShowCount && (
         <View className='ossa-input__count-down'>
           {Number(props.maxLength) - value.length}
         </View>

--- a/packages/ossa/types/input.d.ts
+++ b/packages/ossa/types/input.d.ts
@@ -14,7 +14,15 @@ interface InputProps extends OsComponent {
   isDisabled?: boolean;
   disabledClear?: boolean;
   showSplitLine?: boolean;
+  /**
+   * 是否显示字符计数器，textarea有效，可选
+   * @deprecated `countDown`字段将在未来版本中被移除,请使用`showCount`代替
+   */
   countDown?: boolean;
+  /**
+   * 是否显示字符计数器，textarea有效，可选
+   */
+  showCount?: boolean;
   onChange?: (v: string) => void;
   onFocus?: CommonEventFunction;
   onBlur?: CommonEventFunction;


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NeteaseYanxuan/OSSA/blob/main/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->
<!-- Bugfix or Feature should link relative issue id) -->

**这个 PR 做了什么?** (简要描述所做更改)

目前`input`组件是否显示字符计数器属性名为`countDown`，容易让用户理解为倒计时，增加理解成本和误解的几率，参考其他各大前端组件库的命名规范，建议改为`showCount`。
为了防止`broken change`, 先将`countDown`属性标记为过期属性，暂不删除，同时增加新属性`showCount`,让用户可以平稳过度，在下一个大版本再删除`countDown`属性。

- feat(input): 是否显示字符计数器属性名使用 showCount 属性替代

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) fix #{issue id}
- [ ] 新功能(Feature) resolve #{issue id}
- [X] 代码重构(Refactor)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 类型描述更新(TypeScript definition update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 未涉及平台修改
- [X] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
